### PR TITLE
feat: add public API route

### DIFF
--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -6,8 +6,7 @@ import { Title } from "@components/title";
 import { encrypt } from "pkg/encryption";
 import { ErrorMessage } from "@components/error";
 import { encodeCompositeKey } from "pkg/encoding";
-
-const LATEST_KEY_VERSION = 2;
+import { LATEST_KEY_VERSION } from "pkg/constants";
 
 export default function Home() {
   const [text, setText] = useState("");

--- a/pages/api/v1/secret.ts
+++ b/pages/api/v1/secret.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Redis } from "@upstash/redis";
+import { generateId } from "pkg/id";
+import { encrypt, decrypt} from "pkg/encryption";
+import { encodeCompositeKey, decodeCompositeKey } from 'pkg/encoding';
+import { toBase58 } from 'util/base58';
+import { LATEST_KEY_VERSION } from "pkg/constants";
+
+type PostApiRequest = {
+    ttl?: number;
+    reads?: number;
+    ttlType?: "minutes" | "hours" | "days";
+    secret: string;
+}
+
+type GetApiRequest = {
+    id: string;
+}
+
+const redis = Redis.fromEnv();
+export default async function handler(req: NextRequest): Promise<NextResponse> {
+    if (req.method === "POST") {
+        try {
+            const { ttl = 7, reads = 999, ttlType = "days", secret } = (await req.json()) as PostApiRequest;
+
+            if (!secret) {
+                return new NextResponse("secret param is missing", { status: 400 });
+            }
+            
+            const id = generateId();
+            const { encrypted, iv, key } = await encrypt(secret);
+    
+            const compositeKey = encodeCompositeKey(LATEST_KEY_VERSION, id, key);
+            
+            const rediskey = ["envshare", id].join(":");
+    
+            const tx = redis.multi();
+            
+            tx.hset(rediskey, {
+                remainingReads: reads > 0 ? reads : null,
+                reads,
+                encrypted: toBase58(encrypted),
+                iv: toBase58(iv),
+            });
+            if (ttl) {
+                const ttlMultiplier = ttlType === "minutes" ? 60 : ttlType === "hours" ? 60 * 60 : 60 * 60 * 24;
+                tx.expire(rediskey, ttl * ttlMultiplier);
+            }
+            
+            await tx.exec();
+    
+            const url = new URL(req.url);
+            url.pathname= `/${compositeKey}`;
+    
+            return NextResponse.json({ data: url.href });
+        } catch (e) {
+            console.error(e);
+            return NextResponse.json({error: 'Internal Server Error'}, { status: 500 });
+        }
+    }
+    if (req.method === "GET") {
+        try {
+            const url = new URL(req.url);
+            const apiId = url.searchParams.get("id");
+
+            if (!apiId) {
+                return new NextResponse("id param is missing", { status: 400 });
+            }
+    
+            const { id, encryptionKey, version } = decodeCompositeKey(apiId);
+    
+            const redisKey = ["envshare", id].join(":");
+    
+            const data = await redis.hgetall<{ encrypted: string; remainingReads: number | null; iv: string }>(redisKey);
+            if (!data) {
+                return new NextResponse("Not Found", { status: 404 });
+            }
+            if (data.remainingReads !== null && data.remainingReads < 1) {
+                await redis.del(redisKey);
+                return new NextResponse("Not Found", { status: 404 });
+            }
+    
+            let remainingReads: number | null = null;
+            if (data.remainingReads !== null) {
+                // Decrement the number of reads and return the remaining reads
+                remainingReads = await redis.hincrby(redisKey, "remainingReads", -1);
+            }
+
+            const decrypted = await decrypt(data.encrypted, encryptionKey, data.iv, version);
+    
+            return NextResponse.json({ data: { decrypted, remainingReads } });
+        } catch (e) {
+            console.error(e);
+            return NextResponse.json({error: 'Internal Server Error'}, { status: 500 });
+        }
+    }
+
+    return new NextResponse("", {status: 501});
+}
+
+export const config = {
+    runtime: "edge",
+};

--- a/pages/api/v1/secret.ts
+++ b/pages/api/v1/secret.ts
@@ -13,10 +13,6 @@ type PostApiRequest = {
     secret: string;
 }
 
-type GetApiRequest = {
-    id: string;
-}
-
 const redis = Redis.fromEnv();
 export default async function handler(req: NextRequest): Promise<NextResponse> {
     if (req.method === "POST") {

--- a/pkg/constants.ts
+++ b/pkg/constants.ts
@@ -1,2 +1,3 @@
 export const ID_LENGTH = 16;
 export const ENCRYPTION_KEY_LENGTH = 128;
+export const LATEST_KEY_VERSION = 2;


### PR DESCRIPTION
The code is pretty much identical to the `/store` and `/load` endpoints so I think theres opportunity to consolidate these 2 closely functioning methods, but I get that we wont want to send unencrypted secrets over the wire to the server and back so theres a level of encryption that happens on the frontend first before its sent to the backend. Regardless, I've gone ahead and used those functions to create public API support to create keys and read keys based on a suggestion from: https://github.com/chronark/envshare/issues/3 

**Route**: `POST /api/v1/secret` 
**Body**: 
```jsonc
{
	"reads": 3, // Allowed number of reads for a given secret. Defaults to 999
        "ttl": 3 // How long the secret is valid for. It will expire after that many days/hours/minutes. Defaults to 7
        "ttlType": "days" // One of: ["days" | "hours" | "minutes"]. Denotes the multiplier for the "ttl" value. Defaults to "days"
	"secret": "test" // The secret you're wanting to encrypt
}
```
**Returns**: `data` object containing a URL to the resources to share, the id for programmatic fetching (useful for potential CLI usage or database storage, etc), date the secret expires, time the secret expires, and number of reads initialized.
```jsonc
{
	"data": {
		"url": "http://localhost:3000/unseal#f5HPiMo8wgQFaWmYiFz4koKYM4EyNV54w4GCmEMHD6PB",
		"id": "f5HPiMo8wgQFaWmYiFz4koKYM4EyNV54w4GCmEMHD6PB",
		"expirationDate": "2023-01-24T19:24:12.674Z",
		"expirationTime": 1674588252.674,
                "reads": 3
	}
}
```

**Route**: `GET /api/v1/secret?id=somesecretkey`
**Body**: `Empty`
**Returns**: `data` object with "decrypted" and "remainingReads" key. 
```jsonc
{
	"data": {
		"decrypted": "test", // The decrypted secret
		"remainingReads": 1 // The number of remaining reads allowed on the secret
	}
}
```