### PR TITLE
feat(seo): add remaining seo meta tags

### DIFF
--- a/app/head.tsx
+++ b/app/head.tsx
@@ -15,12 +15,30 @@ export default function Head({ title, subtitle }: { title: string; subtitle: str
     <>
       <title>EnvShare</title>
       <meta content="width=device-width, initial-scale=1" name="viewport" />
-      <meta name="description" content={title} />
+      <meta name="description" content={subtitle} />
+      <meta name="theme-color" content="#000000" />
+      <meta name="title" content={title} />
+      <meta name="keywords" content="envshare, secure, secrets, share, environment, variables" />
+      <meta name="language" content="English" />
+      <meta name="revisit-after" content="7 days" />
+      <meta name="robots" content="all" />
+      <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
+      
+      {/* Open Graph / Facebook */}
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={baseUrl} />
       <meta property='og:image' content={url.toString()} />
       <meta property='og:title' content={title} />
-      <meta property='og:description' content={title} />
+      <meta property='og:description' content={subtitle} />
       <meta property="og:image:width" content="1200" />
       <meta property="og:image:height" content="630" />
+
+      {/* Twitter */}
+      <meta property="twitter:card" content="summary_large_image" />
+      <meta property="twitter:url" content={baseUrl} />
+      <meta property="twitter:title" content={title} />
+      <meta property="twitter:description" content={subtitle} />
+      <meta property="twitter:image" content={url.toString()} />
     </>
   );
 }


### PR DESCRIPTION
Sorry for being slow/late on this. 
Should be a simple addition though. I tested the meta tags we currently have here: https://www.opengraph.xyz/url/https%3A%2F%2Fenvshare.dev and on discord once again
![image](https://user-images.githubusercontent.com/16673873/213584487-d7a10b3a-7f39-4601-9d23-d99066e9851c.png)

And added some more so we can have better embeds. 

I opted to use the name "EnvShare" as the description so we dont have overly repeated text
![image](https://user-images.githubusercontent.com/16673873/213584590-4b8c3c96-5068-4161-954d-af9b0eed58ac.png)

I think it looks better like this:
![image](https://user-images.githubusercontent.com/16673873/213584995-6e85ceed-1c6b-4da8-95e8-0d73f6d0787c.png)

 